### PR TITLE
Feature/cover more file types

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,20 @@
 # Margin Colours
 [![CircleCI](https://circleci.com/gh/chinchiheather/vscode-margin-colours/tree/master.svg?style=shield)](https://circleci.com/gh/chinchiheather/vscode-margin-colours/tree/master)
 
-Display colour badge next to line numbers when any hex/rgb(a)/hsl(a) colours are written anywhere in a JS(ish) file: JavaScript, TypeScript, CoffeeScript, JSON
+Display colour badge next to line numbers when any hex, rgb(a) or hsl(a) colours are written in a file.
 
 This is useful when working with a CSS-in-JS library or with config files that use colour strings.
 
 ![demo](https://chinchiheather.github.io/vscode-margin-colours/img/demo-low-rate.gif)
+
+Supported File Types:
+ * JavaScript
+ * TypeScript
+ * CoffeeScript
+ * JSON
+ * HTML
+ * Jade
+ * PHP
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "vscode-margin-colours",
   "displayName": "Margin Colours",
-  "description": "Display colour badge next to line numbers when any hex/rgb(a)/hsl(a) colours are written anywhere in a JS(ish) file",
-  "version": "1.1.1",
+  "description": "Display colour badge next to line numbers when any hex, rgb(a) or hsl(a) colours are written in a file",
+  "version": "1.2.0",
   "publisher": "chinchiheather",
   "icon": "images/margin-colours-icon.png",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   "activationEvents": [
     "onLanguage:coffeescript",
     "onLanguage:html",
+    "onLanguage:jade",
     "onLanguage:javascript",
     "onLanguage:json",
     "onLanguage:php",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
   ],
   "activationEvents": [
     "onLanguage:coffeescript",
+    "onLanguage:html",
     "onLanguage:javascript",
     "onLanguage:json",
+    "onLanguage:php",
     "onLanguage:typescript"
   ],
   "main": "./src/extension",

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,0 +1,8 @@
+// eslint-disable-next-line max-len
+const colourRegex = /(#(?:[0-9a-fA-F]{2}){2,4}\b|#[0-9a-fA-F]{3}\b|(?:rgba?|hsla?)\(\s*(?:\d+%?(?:,|\s)+){2,3}[\s/]*[\d.]+%?\s*\))/;
+const supportedFileTypes = ['js', 'jsx', 'ts', 'tsx', 'json', 'coffee', 'html', 'jade', 'php'];
+
+module.exports = {
+  colourRegex,
+  supportedFileTypes
+};

--- a/src/extension.js
+++ b/src/extension.js
@@ -1,9 +1,8 @@
 const vscode = require('vscode'); // eslint-disable-line import/no-unresolved
 const fs = require('fs');
 const path = require('path');
+const { colourRegex, supportedFileTypes } = require('./constants');
 
-// eslint-disable-next-line max-len
-const colourRegex = /(#(?:[0-9a-fA-F]{2}){2,4}\b|#[0-9a-fA-F]{3}\b|(?:rgba?|hsla?)\(\s*(?:\d+%?(?:,|\s)+){2,3}[\s/]*[\d.]+%?\s*\))/;
 const decorations = [];
 
 function activate() {
@@ -21,12 +20,17 @@ function deactivate() {
  */
 function addMarginColours() {
   const { document } = vscode.window.activeTextEditor;
+  const { fileName, lineCount, lineAt } = document;
+  const fileExt = fileName.substring(fileName.lastIndexOf('.') + 1);
+  if (supportedFileTypes.indexOf(fileExt) === -1) {
+    return;
+  }
 
   removeMarginColours();
 
   const colours = {};
-  for (let i = 0, len = document.lineCount; i < len; i++) {
-    const line = document.lineAt(i).text;
+  for (let i = 0, len = lineCount; i < len; i++) {
+    const line = lineAt(i).text;
     const matches = line.match(colourRegex);
     if (matches) {
       const colour = matches[0];

--- a/src/test/extension.spec.js
+++ b/src/test/extension.spec.js
@@ -4,6 +4,8 @@
 const mockery = require('mockery');
 const sinon = require('sinon');
 const { expect } = require('chai');
+const { supportedFileTypes } = require('../constants');
+
 
 describe('margin-colours', () => {
   let marginColours;
@@ -35,6 +37,7 @@ describe('margin-colours', () => {
       window: {
         activeTextEditor: {
           document: {
+            fileName: 'my-file.js',
             lineCount: 1,
             lineAt: lineAtFake = sinon.fake(() => ({ text: 'myColour: #123456' }))
           },
@@ -222,7 +225,9 @@ describe('margin-colours', () => {
         'border: 1px solid #cfd234;'
       ]);
       activateExtension();
+    });
 
+    function changeSelection() {
       createDecorationSpy.resetHistory();
       setDecorationsSpy.resetHistory();
       setFileContent([
@@ -231,17 +236,45 @@ describe('margin-colours', () => {
         `background-color: ${newColours[1].colour};`
       ]);
       changeTextEditorSpy.getCall(0).args[0]();
-    });
+    }
 
-    it('removes old colour images', () => {
+    function checkImagesRemoved() {
+      changeSelection();
       expect(disposeSpy).to.have.callCount(3);
+    }
+
+    describe('and file extension is supported', () => {
+      supportedFileTypes.forEach(fileType => (
+        describe(`${fileType} file`, () => {
+          it('removes old colour images', () => {
+            checkImagesRemoved();
+          });
+
+          it('recalculates colour images', () => {
+            const { document } = vscodeMock.window.activeTextEditor;
+            document.fileName = `my-file.${fileType}`;
+            changeSelection();
+            expect(createDecorationSpy).to.have.callCount(2);
+            expect(setDecorationsSpy).to.have.callCount(2);
+            newColours.forEach((colour, idx) => {
+              checkColourImageOnLine(idx, colour.colour, colour.line);
+            });
+          });
+        })
+      ));
     });
 
-    it('recalculates colour images', () => {
-      expect(createDecorationSpy).to.have.callCount(2);
-      expect(setDecorationsSpy).to.have.callCount(2);
-      newColours.forEach((colour, idx) => {
-        checkColourImageOnLine(idx, colour.colour, colour.line);
+    describe('and file extension is not supported', () => {
+      it('removes old colour images', () => {
+        checkImagesRemoved();
+      });
+
+      it('does not recalculates colour images', () => {
+        const { document } = vscodeMock.window.activeTextEditor;
+        document.fileName = 'my-file.sql';
+        changeSelection();
+        expect(createDecorationSpy).not.to.have.been.called;
+        expect(setDecorationsSpy).not.to.have.been.called;
       });
     });
   });

--- a/src/test/extension.spec.js
+++ b/src/test/extension.spec.js
@@ -6,7 +6,6 @@ const sinon = require('sinon');
 const { expect } = require('chai');
 const { supportedFileTypes } = require('../constants');
 
-
 describe('margin-colours', () => {
   let marginColours;
 


### PR DESCRIPTION
Add activation events for html, jade & php

Once activated, only add colours to file types listed in the activation events 