### PR TITLE
Add vscode ignore file

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,0 +1,8 @@
+.github/
+.vscode/
+.vscode-test/
+
+**/*.map
+**/tsconfig.json
+**/tslint.json
+**/*.vsix


### PR DESCRIPTION
This extension is including extra files in its published vsix, specifically the `.vscode-test` folder. This ignore file will prevent those from being published